### PR TITLE
harden README before 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
              `a@@a%@'    `%a@@'       `a@@a%</phant>
              
 ```
-Ascii art by [Susie Oviatt](http://www.roysac.com/tutorial/susieasciiarttutorial.html) -placeholder link until I can find her in particular rather than just her work. 
+Ascii art by Susie Oviatt; tutorial preserved at [roysac.com](http://www.roysac.com/tutorial/susieasciiarttutorial.html).
 
 ## What it does
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ PostgreSQL validates well-formedness on insert; malformed XML is rejected with `
 
 ## Options
 
-- `:decode_binary` — `:copy` (default) or `:reference`. Controls whether decoded values are copied off the receive buffer. `:reference` avoids the copy when you'll process the value before the connection's next message; otherwise stick with the default. Same name and semantics as Postgrex's built-in binary extension.
+- `:decode_binary` — `:copy` (default) or `:reference`. With `:reference` the decoded value is a sub-binary pointing into Postgrex's receive buffer, and that buffer is reused on the next message — retaining the value across messages (storing it in process state, putting it in ETS, sending it to another process) without first calling `:binary.copy/1` reads garbage or crashes the VM. Default to `:copy`; only choose `:reference` when you've measured a copy bottleneck and you fully consume the value inside the same checkout. Same name and semantics as Postgrex's built-in binary extension.
 
 ## A note on untrusted XML
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ PostgreSQL validates well-formedness on insert; malformed XML is rejected with `
 
 ## A note on untrusted XML
 
-This library is a byte passthrough — it does not parse XML in Elixir. PostgreSQL parses on insert (well-formedness only) and again whenever you call `xpath`, `XMLTABLE`, or `xmlexists`. libxml2 expands internal entities, so running XPath or XMLTABLE against attacker-controlled XML is a billion-laughs DoS vector. Treat untrusted XML the way you would in any other Postgres deployment.
+This library is a byte passthrough — it does not parse XML in Elixir. PostgreSQL parses on insert (well-formedness only) and again whenever you call `xpath`, `XMLTABLE`, or `xmlexists`. libxml2 expands internal entities, so running XPath or XMLTABLE against attacker-controlled XML is a billion-laughs DoS vector. Postgres exposes no knob to disable entity expansion; if you handle untrusted XML, sanitize or pre-parse it in your application before insert, and wrap server-side `xpath`/`XMLTABLE`/`xmlexists` calls in a `statement_timeout` so a malicious `<lol9>` payload cannot hold a backend hostage.
 
 ## Running the tests
 


### PR DESCRIPTION
## Summary

Three follow-up fixes to README.md that were split off from the 0.1.0 readiness work on `claude/cool-raman-66d233`:

- **Drop the placeholder ASCII art credit.** The line read \`-placeholder link until I can find her in particular rather than just her work\`, which is a TODO that shouldn't ship to hex.pm. Susie Oviatt's geocities page is dead and I couldn't find a personal page that's still online; reframed the existing roysac.com link as the preserved tutorial rather than as a stand-in.
- **Spell out the \`:reference\` receive-buffer hazard.** Old wording said \"avoids the copy when you'll process the value before the connection's next message; otherwise stick with the default,\" which underplays the consequence. New wording names the failure mode (sub-binary into Postgrex's reused receive buffer; retaining across messages without \`:binary.copy/1\` reads garbage or crashes the VM) and the prerequisite (measure a copy bottleneck and consume in the same checkout).
- **Spell out concrete defenses against billion-laughs.** Existing note flagged the DoS vector but stopped at \"treat untrusted XML the way you would in any other Postgres deployment.\" Added that Postgres has no knob to disable libxml2 entity expansion, so the practical defenses are: sanitize/pre-parse in the app before insert, and wrap server-side \`xpath\`/\`XMLTABLE\`/\`xmlexists\` calls in a \`statement_timeout\`.

Each change is its own commit so history stays bisectable, matching the rest of the readiness work.

## Note on cross-branch consistency

The moduledoc in \`lib/xmlephant/extension.ex\` on \`claude/cool-raman-66d233\` covers the same \`:decode_binary\` ground in less alarmist wording. This branch is off main (cool-raman isn't merged yet) so there's no moduledoc here to update — when cool-raman lands, the moduledoc should be tightened to match the README wording introduced here, or vice versa.

## Test plan

- [x] \`mix docs\` builds cleanly; all three edits render correctly in \`doc/readme.html\`. \`:binary.copy/1\` auto-links to Erlang docs; \`<lol9>\` HTML-escapes.
- [ ] Reviewer eye on the Susie Oviatt rewrite — happy to swap to a better attribution if one is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)