### PR TITLE
link Susie Oviatt's name to her text-mode.org bio

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
              `a@@a%@'    `%a@@'       `a@@a%</phant>
              
 ```
-Ascii art by Susie Oviatt; tutorial preserved at [roysac.com](http://www.roysac.com/tutorial/susieasciiarttutorial.html).
+Ascii art by [Susie Oviatt](https://text-mode.org/?p=24923); tutorial preserved at [roysac.com](http://www.roysac.com/tutorial/susieasciiarttutorial.html).
 
 ## What it does
 


### PR DESCRIPTION
Follow-up to #4. The original placeholder line wished for a link to "her in particular rather than just her work" — text-mode.org has a short biographical post about her (active 1992-1994, blocky-ASCII style) which is the closest thing still online now that her geocities is dead. Wraps her name with that link; keeps the tutorial-preserved-at-roysac.com tail intact.

\`mix docs\` renders both links correctly in \`doc/readme.html\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)