### PR TITLE
add github actions ci that runs mix test against postgres

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: "1.18"
+            otp: "27"
+          - elixir: "1.19.5"
+            otp: "28.4.2"
+
+    name: test (elixir ${{ matrix.elixir }} / otp ${{ matrix.otp }})
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      MIX_ENV: test
+      PG_HOSTNAME: localhost
+      PG_USERNAME: postgres
+      PG_PASSWORD: postgres
+      PG_DATABASE: xmlephant_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      - name: Cache deps and _build
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ matrix.elixir }}-${{ matrix.otp }}-
+
+      - run: mix deps.get
+
+      - run: bin/test_database_setup
+
+      - run: mix test


### PR DESCRIPTION
## Summary

- New `.github/workflows/test.yml` runs `mix test` on every PR (and on pushes to `main`) against a Postgres 17 service container.
- Matrix covers two Elixir/OTP pairs: `1.18 / 27` (the `mix.exs` floor) and `1.19.5 / 28.4.2` (what `polymetis/[redacted]` is currently on, so a regression that would bite that consumer surfaces here).
- Caches `deps` and `_build` per Elixir/OTP combo, keyed on `mix.lock`.

The workflow alone only reports pass/fail; to actually block merges to `main` we still need a branch protection rule requiring these checks. Suggest doing that once the matrix has run green here once so the check names are settled.

## Test plan

- [ ] Both matrix jobs go green on this PR.
- [ ] Cache restore works on a second push (re-trigger after first run lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)